### PR TITLE
Added an option to disable the dropdown option value and show the help text if required.

### DIFF
--- a/src/AutoCompleteForMendix/AutoCompleteForMendix.xml
+++ b/src/AutoCompleteForMendix/AutoCompleteForMendix.xml
@@ -133,7 +133,7 @@
         <property key="_variableContainer" type="object" isList="true" required="true">
             <caption>Template Attributes</caption>
             <category>Result display</category>
-            <description></description>
+			<description/>
             <properties>
                 <property key="variableName" type="string" required="true">
                     <caption>Variable name</caption>
@@ -286,6 +286,19 @@
             <category>Control Display</category>
             <description>A CSS selector used to manage where the dropdown is rendered. E.g. leave empty for a main page, and use .modal-dialog for a modal</description>
         </property>
+	<property key="disableDropdownOption" type="attribute" required="false" entityProperty="dataAssociation">
+			<caption>Disable Dropdown Option</caption>
+			<category>Control Display</category>
+			<description>Boolean attribute based on which the dropdown option will be disabled</description>
+			<attributeTypes>
+				<attributeType name="Boolean"/>
+			</attributeTypes>
+	</property>
+	<property key="disableToolTipMsg" type="translatableString" required="false" multiline="false">
+			<caption>Disable List Tooltip</caption>
+			<category>Control Display</category>
+			<description>Specify the tooptip message for the disabled list values</description>
+	</property>
         <!-- NO RESULT HANDLING PROPERTIES-->
         <property key="noResultsDisplayType" type="enumeration" defaultValue="text">
             <caption>'No results found' display type</caption>
@@ -366,4 +379,3 @@
         </property>
     </properties>
 </widget>
-

--- a/src/AutoCompleteForMendix/widget/AutoCompleteForMendix.js
+++ b/src/AutoCompleteForMendix/widget/AutoCompleteForMendix.js
@@ -6,7 +6,7 @@
     @file      : AutoCompleteForMendix.js
     @version   : 4.0.0
     @author    : Iain Lindsay
-    @date      : 2018-12-19
+    @date      : 2019-06-19
     @copyright : AuraQ Limited 2018
     @license   : Apache V2
 
@@ -758,6 +758,15 @@ define( [
                     }
                 }
 
+	// added below code to capture disable dropdown option value to list
+		if(self.disableDropdownOption){
+                  var disableOption =   availableObject.get(self.disableDropdownOption);
+				 currentVariable.variables.push({
+                            id: self._attributeList.length + 1,
+                            variable: self.disableDropdownOption,
+                            value: disableOption
+                        }); 
+                    }
                 self.variableData.push(currentVariable);                                        
             });  
 
@@ -792,6 +801,25 @@ define( [
                     text: selectedDisplay,
                     dropdownDisplay: div
                 }; 
+		if(this.disableDropdownOption){
+			var disable = false;
+			for(var j = 0; j < this.variableData[i].variables.length; j++)  {
+			if (this.variableData[i].variables[j].variable == this.disableDropdownOption){
+				disable = this.variableData[i].variables[j].value;
+				break; 
+				}
+			}
+			if(disable){
+				item.disabled = true;
+				if (this.disableToolTipMsg !== ""){
+				$(item).attr('title', this.disableToolTipMsg);	
+								
+				}
+								
+                        } else{
+                            item.disabled = false;
+                        }
+                    }
 
                 matches.push(item);
             }


### PR DESCRIPTION
Added the Boolean attribute indicator to the widget based on which the dropdown  option list values will become read only and custom help text message can be shown if required.
