### PR TITLE
Fix no results issue after upgrade to Mx8.18

### DIFF
--- a/src/AutoCompleteForMendix/widget/AutoCompleteForMendix.js
+++ b/src/AutoCompleteForMendix/widget/AutoCompleteForMendix.js
@@ -689,12 +689,19 @@ define( [
                         }
                     }
 
+                    var xpathAmount;
+                    if (self.maxRecords === 0) {
+                        xpathAmount = -1;
+                    } else {
+                        xpathAmount = self.maxRecords;
+                    }
+
                     mx.data.get({
                         xpath: xpath,
                         filter: {
                             sort: self._sortParams,
                             offset: 0,
-                            amount: self.maxRecords
+                            amount: xpathAmount
                         },
                         callback: searchCallback
                     });


### PR DESCRIPTION
Mendix 8.18.x treats a zero not as no maximum but as a value so the API call returns empty. Setting the value to -1 when a zero is passed makes the widget work again.