### PR TITLE
Prevent browser refresh on clicking no result microflow link.

### DIFF
--- a/src/AutoCompleteForMendix/widget/AutoCompleteForMendix.js
+++ b/src/AutoCompleteForMendix/widget/AutoCompleteForMendix.js
@@ -356,7 +356,8 @@ define( [
                                 href:"#",
                                 innerHTML: self.noResultsText,
                                 'class':"btn btn-block btn-noResults",
-                                onclick:function(){
+                                onclick:function(event){
+                                    event.preventDefault();
                                     self._contextObj.set(self.noResultsSearchStringAttribute, self._currentSearchTerm);
                                     self._execMf(self._contextObj.getGuid(), self.noResultsMicroflow);
                                     self._$combo.select2("close");


### PR DESCRIPTION
Related to #65 

Starting Mendix 8.14 an onclick event is propagated through the DOM.
This causes the browser to reload the page, when click the noresult link in the autocompletewidget. 
This fix prevents the onclick event being handled by the 'browser'.
